### PR TITLE
Refactor: 모달창 카테고리 태그에 hover 시 underline 효과 삭제, 메인페이지 검색 결과 렌더 조건 수정

### DIFF
--- a/src/components/common/CategoryBox.jsx
+++ b/src/components/common/CategoryBox.jsx
@@ -13,14 +13,18 @@ const EachCategoryBox = styled.div`
       border-bottom: 2px solid var(--primary-color);
     `}
 
-  :hover {
-    ${({ selected }) =>
-      !selected &&
-      `
-      transition: none;
-      border-bottom: 2px solid #ababab;
+  ${({ underlineOnHover }) =>
+    underlineOnHover &&
+    `
+        :hover {
+          ${({ selected }) =>
+            !selected &&
+            `
+            transition: none;
+            border-bottom: 2px solid #ababab;
+          `}
+        }
     `}
-  }
 
   ${({ changeOnHover }) =>
     changeOnHover &&
@@ -59,12 +63,17 @@ const CategoryBox = ({
   colored,
   selected,
   changeOnHover = true,
+  underlineOnHover = true,
   iconWidth = '50%',
 }) => {
   const imgSrc = `/categoryIcons/${colored ? '' : 'noColor/'}${categoryImgFile}.png`;
 
   return (
-    <EachCategoryBox selected={selected} onClick={clickHandler} changeOnHover={changeOnHover}>
+    <EachCategoryBox
+      selected={selected}
+      onClick={clickHandler}
+      changeOnHover={changeOnHover}
+      underlineOnHover={underlineOnHover}>
       {/* <SelectedIcon /> */}
       <CategoryIcon src={imgSrc} alt={`${categoryName}`} width={iconWidth} />
       <CategoryName selected={selected}>{categoryName}</CategoryName>

--- a/src/components/main/InfiniteStoreList.jsx
+++ b/src/components/main/InfiniteStoreList.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
+import { useRecoilValue } from 'recoil';
+import { searchInputState } from '../../recoil/atoms';
 import { StoreItem, ScrollObserver } from '../common';
 import { StoreItemOnHover, NoResultMessage } from '.';
 
@@ -71,12 +73,15 @@ let displayedStores = { topThree: [], remaining: [] };
 const InfiniteStoreList = ({ data, fetchNextPage, hasNextPage }) => {
   const searchedStores = data.pages.flat();
   const [topThree, remaining] = [searchedStores.slice(0, 3), searchedStores.slice(3)];
+  const searchedInput = useRecoilValue(searchInputState);
 
-  displayedStores = { topThree, remaining };
+  displayedStores = searchedInput ? { topThree: [], remaining: searchedStores } : { topThree, remaining };
 
   return (
     <>
-      {displayedStores.topThree.length ? (
+      {searchedInput && !displayedStores.remaining.length ? (
+        <NoResultMessage />
+      ) : (
         <StoresContainer>
           <TopStoresContainer>
             {displayedStores.topThree.map(({ storeId, storeName, votesByCategory, address, starsCount }, idx) => (
@@ -107,8 +112,6 @@ const InfiniteStoreList = ({ data, fetchNextPage, hasNextPage }) => {
           </RestStoresContainer>
           {hasNextPage && <ScrollObserver fetchNextPage={fetchNextPage} />}
         </StoresContainer>
-      ) : (
-        <NoResultMessage />
       )}
     </>
   );

--- a/src/components/modal/CategorySelector.jsx
+++ b/src/components/modal/CategorySelector.jsx
@@ -116,6 +116,7 @@ const CategorySelector = ({
             categoryName={categoryInfo[categoryCode].ko}
             categoryImgFile={categoryInfo[categoryCode].imgFile}
             changeOnHover={false}
+            underlineOnHover={false}
             colored
           />
         ) : (
@@ -133,6 +134,7 @@ const CategorySelector = ({
               colored={categoryCode === code}
               key={categoryInfo[code].ko}
               clickHandler={() => setCategoryCode(code)}
+              underlineOnHover={false}
             />
           );
         })}


### PR DESCRIPTION
- CategoryBox 컴포넌트에 'underlineOnHover' 프롭 추가. 모달창에서 hover시 underline 효과 들어가지 않도록 수정
- 메인페이지에서 검색 시, TopStoresContainer 렌더링 하지 않도록 로직 변경 